### PR TITLE
use `md5` on macOS for tempdir names

### DIFF
--- a/t/tmpdir.bash
+++ b/t/tmpdir.bash
@@ -1,5 +1,14 @@
+for sum in md5sum md5
+do
+  if which -s $sum
+  then
+    CHECKSUM=$(which $sum)
+    break
+  fi
+done
+
 function get_tempdir_name() {
-  echo "$BATS_TMPDIR/$( echo ${1:-$BATS_TEST_FILENAME} $PPID | md5sum | awk '{ print $1 }' )"
+  echo "$BATS_TMPDIR/$( echo ${1:-$BATS_TEST_FILENAME} $PPID | $CHECKSUM | awk '{ print $1 }' )"
 }
 
 function make_tempdir() {

--- a/t/tmpdir.bash
+++ b/t/tmpdir.bash
@@ -1,6 +1,6 @@
 for sum in md5sum md5
 do
-  if which -s $sum
+  if which $sum >/dev/null
   then
     CHECKSUM=$(which $sum)
     break


### PR DESCRIPTION
fixes #3 