### PR TITLE
Convert BATS_TMPDIR to an absolute path before creating a tempdir in it

### DIFF
--- a/t/tmpdir.bash
+++ b/t/tmpdir.bash
@@ -7,8 +7,10 @@ do
   fi
 done
 
+ABS_BATS_TMPDIR=$( cd "$BATS_TMPDIR"; /bin/pwd -P )
+
 function get_tempdir_name() {
-  echo "$BATS_TMPDIR/$( echo ${1:-$BATS_TEST_FILENAME} $PPID | $CHECKSUM | awk '{ print $1 }' )"
+  echo "$ABS_BATS_TMPDIR/$( echo ${1:-$BATS_TEST_FILENAME} $PPID | $CHECKSUM | awk '{ print $1 }' )"
 }
 
 function make_tempdir() {


### PR DESCRIPTION
Since detect_virtualenv returns the real absolute path to discovered
directories, the test case needs to know the absolute real path to the
directories used for testing, so it can compare the expected path
successfully with the actual path found.

Here's an example to illustrate: say the test directories were created
in `/tmp`, which is a symlink to `/var/tmp`. Starting in `/tmp/foo/bar`
and searching for `bie` (assuming `/tmp/foo/{bar,bie}` exist),
`find_dir_in_parents` would return `/var/tmp/foo/bie`, but the test
would expect `/tmp/foo/bie` (as it is `$tempdir` + `foo/bie`).

Fixes #2