### PR TITLE
Use short forms of command line options for rm

### DIFF
--- a/t/tmpdir.bash
+++ b/t/tmpdir.bash
@@ -21,5 +21,5 @@ function make_tempdir() {
 
 function rm_tempdir() {
   local tempdir=$( get_tempdir_name $1 )
-  rm --recursive --force -- "$tempdir"
+  rm -rf -- "$tempdir"
 }


### PR DESCRIPTION
macOS uses BSD-derived utils, which don't have the GNU long form options

fixes #9