### PR TITLE
Change nested loops to a pipeline of filter functions

### DIFF
--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -113,6 +113,11 @@ function status_should_be() {
     esac
 }
 
+function first0() {
+    IFS= read -r -d '' first
+    printf "%s" "$first"
+}
+
 function detect_virtualenv() {
     local -a args=()
     while [ "$#" -gt 0 ]
@@ -134,10 +139,7 @@ function detect_virtualenv() {
     local names=${args[0]:-$MY_VIRTUALENV_NAMES}
     IFS=':' read -ra virtualenv_names <<< "$names"
 
-    exec 31< <( find_virtualenvs "${virtualenv_names[@]}"; printf '\0' )
-    read -r -d '' -u 31 first
-    echo $first >> /tmp/hi
-    exec 31<&-
+    first=$( find_virtualenvs "${virtualenv_names[@]}" | first0 )
     switch_virtualenvs "$first"
 }
 

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -25,7 +25,7 @@ function ancestors_of() {
     local last
     while [ "$dir" != "$last" ]
     do
-        printf "%s\0" "${dir%/}/"
+        printf "%s\0" "${dir%/}"
         last="$dir"
         dir=$( dirname "$dir" )
     done
@@ -38,9 +38,9 @@ function match_parent() {
     local ancestor_parent="$( dirname "$1" )"
     while read -r -d '' parent
     do
-        if [ "$parent" = "${ancestor_parent%/}/" ]
+        if [ "$parent" = "$ancestor_parent" ]
         then
-            printf "%s/\0" "${1%/}"
+            printf "%s\0" "${1%/}"
             break
         fi
     done
@@ -51,7 +51,7 @@ function append_relpath() {
     do
         for child in "$@"
         do
-            printf "%s%s/\0" "$parent" "$child"
+            printf "%s/%s\0" "$parent" "$child"
         done
     done
 }
@@ -59,7 +59,7 @@ function append_relpath() {
 function has_activate_script() {
     while read -r -d '' candidate
     do
-        [ -e "${candidate}bin/activate" ] && printf "%s\0" "$candidate"
+        [ -e "${candidate}/bin/activate" ] && printf "%s\0" "$candidate"
     done
 }
 

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -89,7 +89,7 @@ function first0() {
 }
 
 function detect_virtualenv() {
-    local -a args=()
+    local -a args
     while [ "$#" -gt 0 ]
     do
         local arg="$1"; shift

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -34,9 +34,12 @@ function ancestors_of() {
 function find_dir_in_parents() {
     local needle=$1
     test -n "$needle" || return
+    # might be the current virtualenv, which is an absolute path
+    local needle_dir=$( dirname "$needle" )
+
     local look=$( abs_path ${2:-.} )
     test -d "$look" || return
-    local needle_dir=$( dirname "$needle" )
+
     while [ "$( dirname "$look" )" != "$look" ]
     do
         if [ "$( builtin cd "$look"; abs_path $needle_dir )" = "$look" ]

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -64,27 +64,7 @@ function has_activate_script() {
 }
 
 function find_virtualenvs() {
-    ancestors_of | tee  >( append_relpath "$@" ) | match_parent "$VIRTUAL_ENV" | has_activate_script
-}
-
-function find_dir_in_parents() {
-    local needle=$1
-    test -n "$needle" || return
-    # might be the current virtualenv, which is an absolute path
-    local needle_dir=$( dirname "$needle" )
-
-    local look=$( abs_path ${2:-.} )
-    test -d "$look" || return
-
-    while [ "$( dirname "$look" )" != "$look" ]
-    do
-        if [ "$( builtin cd "$look"; abs_path $needle_dir )" = "$look" ]
-        then
-            local candidate=$look/${needle#$look/}
-            test -d "$candidate" && echo $candidate && break
-        fi
-        look=$( dirname "$look" )
-    done
+    ancestors_of | tee >( append_relpath "$@" ) | match_parent "$VIRTUAL_ENV" | has_activate_script
 }
 
 function switch_virtualenvs() {

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -36,7 +36,7 @@ function match_parent() {
     #   /foo/bie
     [ -z "$1" ] && return
     local ancestor_parent="$( dirname "$1" )"
-    while read -r -d '' parent
+    while IFS= read -r -d '' parent
     do
         if [ "$parent" = "$ancestor_parent" ]
         then
@@ -47,7 +47,7 @@ function match_parent() {
 }
 
 function append_relpath() {
-    while read -r -d '' parent
+    while IFS= read -r -d '' parent
     do
         for child in "$@"
         do
@@ -57,7 +57,7 @@ function append_relpath() {
 }
 
 function has_activate_script() {
-    while read -r -d '' candidate
+    while IFS= read -r -d '' candidate
     do
         [ -e "${candidate}/bin/activate" ] && printf "%s\0" "$candidate"
     done

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -59,7 +59,7 @@ function append_relpath() {
 function has_activate_script() {
     while IFS= read -r -d '' candidate
     do
-        [ -e "${candidate}/bin/activate" ] && printf "%s\0" "$candidate"
+        [ -r "${candidate}/bin/activate" ] && printf "%s\0" "$candidate"
     done
 }
 

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -20,6 +20,17 @@ else
     }
 fi
 
+function ancestors_of() {
+    local dir=$( abs_path "${1:-.}" )
+    local last
+    while [ "$dir" != "$last" ]
+    do
+        echo "${dir%/}/"
+        last="$dir"
+        dir=$( dirname "$dir" )
+    done
+}
+
 function find_dir_in_parents() {
     local needle=$1
     test -n "$needle" || return

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -64,7 +64,7 @@ function has_activate_script() {
 }
 
 function find_virtualenvs() {
-    ancestors_of | tee >( append_relpath "$@" ) | match_parent "$VIRTUAL_ENV" | has_activate_script
+    ancestors_of | tee >( append_relpath "$@" ) >( match_parent "$VIRTUAL_ENV" ) >/dev/null | has_activate_script
 }
 
 function switch_virtualenvs() {

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -31,6 +31,21 @@ function ancestors_of() {
     done
 }
 
+function match_parent() {
+    # ancestors_of /foo/bar/baz | match_parent /foo/bie
+    #   /foo/bie
+    [ -z "$1" ] && return
+    ancestor_parent="$( dirname "$1" )"
+    while read -r -d '' parent
+    do
+        if [ "$parent" = "${ancestor_parent%/}/" ]
+        then
+            printf "%s\0" "$1"
+            break
+        fi
+    done
+}
+
 function find_dir_in_parents() {
     local needle=$1
     test -n "$needle" || return

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -34,16 +34,18 @@ function ancestors_of() {
 function match_parent() {
     # ancestors_of /foo/bar/baz | match_parent /foo/bie
     #   /foo/bie
-    [ -z "$1" ] && return
-    local ancestor_parent="$( dirname "$1" )"
-    while IFS= read -r -d '' parent
-    do
-        if [ "$parent" = "$ancestor_parent" ]
-        then
-            printf "%s\0" "${1%/}"
-            break
-        fi
-    done
+    if [ -n "$1" ]
+    then
+        local ancestor_parent="$( dirname "$1" )"
+        while IFS= read -r -d '' parent
+        do
+            if [ "$parent" = "$ancestor_parent" ]
+            then
+                printf "%s\0" "${1%/}"
+                break
+            fi
+        done
+    fi
 }
 
 function append_relpath() {

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -11,7 +11,7 @@ function ancestors_of() {
     local last
     while [ "$dir" != "$last" ]
     do
-        printf "%s\0" "${dir%/}"
+        printf "%q\n" "${dir%/}"
         last="$dir"
         dir=$( dirname "$dir" )
     done
@@ -20,35 +20,25 @@ function ancestors_of() {
 function match_parent() {
     # ancestors_of /foo/bar/baz | match_parent /foo/bie
     #   /foo/bie
-    if [ -n "$1" ]
-    then
-        local ancestor_parent="$( dirname "$1" )"
-        while IFS= read -r -d '' parent
-        do
-            if [ "$parent" = "$ancestor_parent" ]
-            then
-                printf "%s\0" "${1%/}"
-                break
-            fi
-        done
-    fi
-    cat > /dev/null
+    printf -v ancestor_parent "%q" "$( dirname "$1" )"
+    grep -F -q "$ancestor_parent" && printf "%q\n" "$1" && cat >/dev/null
 }
 
 function append_relpath() {
-    while IFS= read -r -d '' parent
+    while read -r parent
     do
         for child in "$@"
         do
-            printf "%s/%s\0" "$parent" "$child"
+            printf "%s/%q\n" "$parent" "$child"
         done
     done
 }
 
 function has_activate_script() {
-    while IFS= read -r -d '' candidate
+    while read -r candidate
     do
-        [ -r "${candidate}/bin/activate" ] && printf "%s\0" "$candidate"
+        local unescaped_candidate="$( eval echo "$candidate" )"
+        [ -r "${unescaped_candidate}/bin/activate" ] && echo "$candidate"
     done
 }
 
@@ -82,12 +72,6 @@ function status_should_be() {
     esac
 }
 
-function first0() {
-    IFS= read -r -d '' first
-    printf "%s" "$first"
-    cat > /dev/null
-}
-
 function detect_virtualenv() {
     local -a args
     while [ "$#" -gt 0 ]
@@ -109,7 +93,7 @@ function detect_virtualenv() {
     local names=${args[0]:-$MY_VIRTUALENV_NAMES}
     IFS=':' read -ra virtualenv_names <<< "$names"
 
-    first=$( find_virtualenvs "${virtualenv_names[@]}" | first0 )
+    first="$( eval echo "$( find_virtualenvs "${virtualenv_names[@]}" | head -1 )" )"
     switch_virtualenvs "$first"
 }
 

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -40,9 +40,19 @@ function match_parent() {
     do
         if [ "$parent" = "${ancestor_parent%/}/" ]
         then
-            printf "%s\0" "$1"
+            printf "%s/\0" "${1%/}"
             break
         fi
+    done
+}
+
+function append_relpath() {
+    while read -r -d '' parent
+    do
+        for child in "$@"
+        do
+            printf "%s%s/\0" "$parent" "$child"
+        done
     done
 }
 

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -63,6 +63,10 @@ function has_activate_script() {
     done
 }
 
+function find_virtualenvs() {
+    ancestors_of | tee  >( append_relpath "$@" ) | match_parent "$VIRTUAL_ENV" | has_activate_script
+}
+
 function find_dir_in_parents() {
     local needle=$1
     test -n "$needle" || return
@@ -128,14 +132,13 @@ function detect_virtualenv() {
     fi
 
     local names=${args[0]:-$MY_VIRTUALENV_NAMES}
-    IFS=':' read -ra dirs <<< "${VIRTUAL_ENV:+$VIRTUAL_ENV:}$names"
-    local found
-    for dir in "${dirs[@]}"
-    do
-        local found=$( find_dir_in_parents "$dir" )
-        [ -n "$found" ] && break
-    done
-    switch_virtualenvs "$found"
+    IFS=':' read -ra virtualenv_names <<< "$names"
+
+    exec 31< <( find_virtualenvs "${virtualenv_names[@]}"; printf '\0' )
+    read -r -d '' -u 31 first
+    echo $first >> /tmp/hi
+    exec 31<&-
+    switch_virtualenvs "$first"
 }
 
 function detect_virtualenv_on_prompt() {

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -56,6 +56,13 @@ function append_relpath() {
     done
 }
 
+function has_activate_script() {
+    while read -r -d '' candidate
+    do
+        [ -e "${candidate}bin/activate" ] && printf "%s\0" "$candidate"
+    done
+}
+
 function find_dir_in_parents() {
     local needle=$1
     test -n "$needle" || return

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -11,7 +11,7 @@ function ancestors_of() {
     local last
     while [ "$dir" != "$last" ]
     do
-        printf "%q\n" "${dir%/}"
+        printf "%q\n" "${dir%/}" 2>/dev/null
         last="$dir"
         dir=$( dirname "$dir" )
     done
@@ -21,7 +21,7 @@ function match_parent() {
     # ancestors_of /foo/bar/baz | match_parent /foo/bie
     #   /foo/bie
     printf -v ancestor_parent "%q" "$( dirname "$1" )"
-    grep -F -q "$ancestor_parent" && printf "%q\n" "$1" && cat >/dev/null
+    grep -F -q "$ancestor_parent" && printf "%q\n" "$1" 2>/dev/null
 }
 
 function append_relpath() {
@@ -29,7 +29,7 @@ function append_relpath() {
     do
         for child in "$@"
         do
-            printf "%s/%q\n" "$parent" "$child"
+            printf "%s/%q\n" "$parent" "$child" 2>/dev/null
         done
     done
 }
@@ -38,7 +38,7 @@ function has_activate_script() {
     while read -r candidate
     do
         local unescaped_candidate="$( eval echo "$candidate" )"
-        [ -r "${unescaped_candidate}/bin/activate" ] && echo "$candidate"
+        [ -r "${unescaped_candidate}/bin/activate" ] && echo "$candidate" 2>/dev/null
     done
 }
 

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -27,10 +27,7 @@ function match_parent() {
 function append_relpath() {
     while read -r parent
     do
-        for child in "$@"
-        do
-            printf "%s/%q\n" "$parent" "$child" 2>/dev/null
-        done
+        printf "$parent/%q\n" "$@" 2>/dev/null
     done
 }
 

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -35,7 +35,7 @@ function match_parent() {
     # ancestors_of /foo/bar/baz | match_parent /foo/bie
     #   /foo/bie
     [ -z "$1" ] && return
-    ancestor_parent="$( dirname "$1" )"
+    local ancestor_parent="$( dirname "$1" )"
     while read -r -d '' parent
     do
         if [ "$parent" = "${ancestor_parent%/}/" ]

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -46,6 +46,7 @@ function match_parent() {
             fi
         done
     fi
+    cat > /dev/null
 }
 
 function append_relpath() {
@@ -98,6 +99,7 @@ function status_should_be() {
 function first0() {
     IFS= read -r -d '' first
     printf "%s" "$first"
+    cat > /dev/null
 }
 
 function detect_virtualenv() {

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -1,24 +1,10 @@
 MY_VIRTUALENV_NAMES=${MY_VIRTUALENV_NAMES:-.venv}
 DETECT_VIRTUALENV_STATUS=on
 
-function abs_path_readlink() {
-    readlink --canonicalize "$1"
+function abs_path() {
+    builtin cd "$1"
+    /bin/pwd -P
 }
-
-function abs_path_perl() {
-    perl -MCwd=abs_path -e'print abs_path(shift)' "$1"
-}
-
-if abs_path_readlink >/dev/null 2>&1
-then
-    function abs_path() {
-        abs_path_readlink $@
-    }
-else
-    function abs_path() {
-        abs_path_perl $@
-    }
-fi
 
 function ancestors_of() {
     local dir=$( abs_path "${1:-.}" )

--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -25,7 +25,7 @@ function ancestors_of() {
     local last
     while [ "$dir" != "$last" ]
     do
-        echo "${dir%/}/"
+        printf "%s\0" "${dir%/}/"
         last="$dir"
         dir=$( dirname "$dir" )
     done

--- a/t/ancestors_of.bats
+++ b/t/ancestors_of.bats
@@ -1,0 +1,72 @@
+load begin_and_end
+load tmpdir
+
+function setup() {
+  begin && run setup_corpus
+  PATH="$BATS_TEST_DIRNAME/..:$PATH"
+  source detect_virtualenv
+}
+
+function teardown() {
+  end && run teardown_corpus
+  true
+}
+
+function setup_corpus() {
+  local tempdir=$( make_tempdir )
+  #
+  # $tempdir
+  # ├── foo
+  # │   ├── bar
+  # │   │   └── baz
+  # │   └── bie
+  # │       └── bletch
+  # └── quux
+  #     └── quuux
+  #
+  mkdir -p "$tempdir"/foo/{bar/baz,bie/bletch}
+  mkdir -p "$tempdir"/quux/quuux
+  ln -s foo/bie "$tempdir"/foobie
+}
+
+function teardown_corpus() {
+  rm_tempdir
+}
+
+@test "lists parents" {
+  local tempdir=$( get_tempdir_name )
+  local -a parents
+  # pipelines create subshells, which don;t update variables in the parent
+  exec 99< <( ancestors_of "$tempdir/foo/bar" )
+  while read -r parent
+  do
+      parents+=("$parent")
+  done <&99
+  exec 99<&-
+
+  [ "${parents[0]}" = "$tempdir/foo/bar/" ]
+  [ "${parents[1]}" = "$tempdir/foo/" ]
+  [ "${parents[2]}" = "$tempdir/" ]
+  [ "${parents[${#parents[@]} - 2]}" != "/" ]
+  [ "${parents[${#parents[@]} - 1]}" = "/" ]
+}
+
+@test "lists parents resolves symlinks" {
+  local tempdir=$( get_tempdir_name )
+  local -a parents
+  # pipelines create subshells, which don;t update variables in the parent
+  exec 99< <( ancestors_of "$tempdir/foobie" )
+  while read -r parent
+  do
+      parents+=("$parent")
+  done <&99
+  exec 99<&-
+
+  [ "${parents[0]}" = "$tempdir/foo/bie/" ]
+  [ "${parents[1]}" = "$tempdir/foo/" ]
+  [ "${parents[2]}" = "$tempdir/" ]
+  [ "${parents[${#parents[@]} - 2]}" != "/" ]
+  [ "${parents[${#parents[@]} - 1]}" = "/" ]
+}
+
+# vim: ft=sh

--- a/t/ancestors_of.bats
+++ b/t/ancestors_of.bats
@@ -5,6 +5,7 @@ function setup() {
   begin && run setup_corpus
   PATH="$BATS_TEST_DIRNAME/..:$PATH"
   source detect_virtualenv
+  tempdir=$( get_tempdir_name )
 }
 
 function teardown() {
@@ -34,7 +35,6 @@ function teardown_corpus() {
 }
 
 @test "lists parents" {
-  local tempdir=$( get_tempdir_name )
   local -a parents
   # pipelines create subshells, which don;t update variables in the parent
   exec 99< <( ancestors_of "$tempdir/foo/bar" )
@@ -52,7 +52,6 @@ function teardown_corpus() {
 }
 
 @test "lists parents resolves symlinks" {
-  local tempdir=$( get_tempdir_name )
   local -a parents
   # pipelines create subshells, which don;t update variables in the parent
   exec 99< <( ancestors_of "$tempdir/foobie" )

--- a/t/ancestors_of.bats
+++ b/t/ancestors_of.bats
@@ -37,12 +37,12 @@ function teardown_corpus() {
 @test "lists parents" {
   local -a parents
   # pipelines create subshells, which don;t update variables in the parent
-  exec 99< <( ancestors_of "$tempdir/foo/bar" )
+  exec 4< <( ancestors_of "$tempdir/foo/bar" )
   while IFS= read -r -d '' parent
   do
       parents+=("$parent")
-  done <&99
-  exec 99<&-
+  done <&4
+  exec 4<&-
 
   [ "${parents[0]}" = "$tempdir/foo/bar" ]
   [ "${parents[1]}" = "$tempdir/foo" ]
@@ -54,12 +54,12 @@ function teardown_corpus() {
 @test "lists parents resolves symlinks" {
   local -a parents
   # pipelines create subshells, which don;t update variables in the parent
-  exec 99< <( ancestors_of "$tempdir/foobie" )
+  exec 4< <( ancestors_of "$tempdir/foobie" )
   while IFS= read -r -d '' parent
   do
       parents+=("$parent")
-  done <&99
-  exec 99<&-
+  done <&4
+  exec 4<&-
 
   [ "${parents[0]}" = "$tempdir/foo/bie" ]
   [ "${parents[1]}" = "$tempdir/foo" ]

--- a/t/ancestors_of.bats
+++ b/t/ancestors_of.bats
@@ -44,11 +44,11 @@ function teardown_corpus() {
   done <&99
   exec 99<&-
 
-  [ "${parents[0]}" = "$tempdir/foo/bar/" ]
-  [ "${parents[1]}" = "$tempdir/foo/" ]
-  [ "${parents[2]}" = "$tempdir/" ]
-  [ "${parents[${#parents[@]} - 2]}" != "/" ]
-  [ "${parents[${#parents[@]} - 1]}" = "/" ]
+  [ "${parents[0]}" = "$tempdir/foo/bar" ]
+  [ "${parents[1]}" = "$tempdir/foo" ]
+  [ "${parents[2]}" = "$tempdir" ]
+  [ "${parents[${#parents[@]} - 2]}" != "" ]
+  [ "${parents[${#parents[@]} - 1]}" = "" ]
 }
 
 @test "lists parents resolves symlinks" {
@@ -62,11 +62,11 @@ function teardown_corpus() {
   done <&99
   exec 99<&-
 
-  [ "${parents[0]}" = "$tempdir/foo/bie/" ]
-  [ "${parents[1]}" = "$tempdir/foo/" ]
-  [ "${parents[2]}" = "$tempdir/" ]
-  [ "${parents[${#parents[@]} - 2]}" != "/" ]
-  [ "${parents[${#parents[@]} - 1]}" = "/" ]
+  [ "${parents[0]}" = "$tempdir/foo/bie" ]
+  [ "${parents[1]}" = "$tempdir/foo" ]
+  [ "${parents[2]}" = "$tempdir" ]
+  [ "${parents[${#parents[@]} - 2]}" != "" ]
+  [ "${parents[${#parents[@]} - 1]}" = "" ]
 }
 
 # vim: ft=sh

--- a/t/ancestors_of.bats
+++ b/t/ancestors_of.bats
@@ -38,7 +38,7 @@ function teardown_corpus() {
   local -a parents
   # pipelines create subshells, which don;t update variables in the parent
   exec 99< <( ancestors_of "$tempdir/foo/bar" )
-  while read -r -d '' parent
+  while IFS= read -r -d '' parent
   do
       parents+=("$parent")
   done <&99
@@ -56,7 +56,7 @@ function teardown_corpus() {
   local -a parents
   # pipelines create subshells, which don;t update variables in the parent
   exec 99< <( ancestors_of "$tempdir/foobie" )
-  while read -r -d '' parent
+  while IFS= read -r -d '' parent
   do
       parents+=("$parent")
   done <&99

--- a/t/ancestors_of.bats
+++ b/t/ancestors_of.bats
@@ -35,37 +35,23 @@ function teardown_corpus() {
 }
 
 @test "lists parents" {
-  local -a parents
-  # pipelines create subshells, which don;t update variables in the parent
-  exec 4< <( ancestors_of "$tempdir/foo/bar" )
-  while IFS= read -r -d '' parent
-  do
-      parents+=("$parent")
-  done <&4
-  exec 4<&-
+  IFS=$'\n' read -d'' -r -a parents < <( ancestors_of "$tempdir/foo/bar" ) || true
 
   [ "${parents[0]}" = "$tempdir/foo/bar" ]
   [ "${parents[1]}" = "$tempdir/foo" ]
   [ "${parents[2]}" = "$tempdir" ]
-  [ "${parents[${#parents[@]} - 2]}" != "" ]
-  [ "${parents[${#parents[@]} - 1]}" = "" ]
+  [ "${parents[${#parents[@]} - 2]}" != "''" ]
+  [ "${parents[${#parents[@]} - 1]}" = "''" ]
 }
 
 @test "lists parents resolves symlinks" {
-  local -a parents
-  # pipelines create subshells, which don;t update variables in the parent
-  exec 4< <( ancestors_of "$tempdir/foobie" )
-  while IFS= read -r -d '' parent
-  do
-      parents+=("$parent")
-  done <&4
-  exec 4<&-
+  IFS=$'\n' read -d'' -r -a parents < <( ancestors_of "$tempdir/foobie" ) || true
 
   [ "${parents[0]}" = "$tempdir/foo/bie" ]
   [ "${parents[1]}" = "$tempdir/foo" ]
   [ "${parents[2]}" = "$tempdir" ]
-  [ "${parents[${#parents[@]} - 2]}" != "" ]
-  [ "${parents[${#parents[@]} - 1]}" = "" ]
+  [ "${parents[${#parents[@]} - 2]}" != "''" ]
+  [ "${parents[${#parents[@]} - 1]}" = "''" ]
 }
 
 # vim: ft=sh

--- a/t/ancestors_of.bats
+++ b/t/ancestors_of.bats
@@ -38,7 +38,7 @@ function teardown_corpus() {
   local -a parents
   # pipelines create subshells, which don;t update variables in the parent
   exec 99< <( ancestors_of "$tempdir/foo/bar" )
-  while read -r parent
+  while read -r -d '' parent
   do
       parents+=("$parent")
   done <&99
@@ -56,7 +56,7 @@ function teardown_corpus() {
   local -a parents
   # pipelines create subshells, which don;t update variables in the parent
   exec 99< <( ancestors_of "$tempdir/foobie" )
-  while read -r parent
+  while read -r -d '' parent
   do
       parents+=("$parent")
   done <&99

--- a/t/append_relpath.bats
+++ b/t/append_relpath.bats
@@ -1,0 +1,16 @@
+function setup() {
+  PATH="$BATS_TEST_DIRNAME/..:$PATH"
+  source detect_virtualenv
+}
+
+@test "creates candidates for all possible names" {
+  IFS=$'\n' read -d'' -r -a found < <( printf "%s\0" /foo/bar/baz/ /foo/bar/ /foo/ / | append_relpath hi hello howdy | tr '\0' '\n' ) || true
+  [ "${found[0]}" = "/foo/bar/baz/hi" ]
+  [ "${found[1]}" = "/foo/bar/baz/hello" ]
+  [ "${found[2]}" = "/foo/bar/baz/howdy" ]
+  [ "${found[3]}" = "/foo/bar/hi" ]
+  [ "${found[7]}" = "/foo/hello" ]
+  [ "${found[${#found[@]} - 1]}" = "/howdy" ]
+}
+
+# vim: ft=sh

--- a/t/append_relpath.bats
+++ b/t/append_relpath.bats
@@ -4,13 +4,13 @@ function setup() {
 }
 
 @test "creates candidates for all possible names" {
-  IFS=$'\n' read -d'' -r -a found < <( printf "%s\0" /foo/bar/baz/ /foo/bar/ /foo/ / | append_relpath hi hello howdy | tr '\0' '\n' ) || true
+  IFS=$'\n' read -d'' -r -a found < <( printf "%q\n" /foo/bar/baz /foo/bar /foo '' | append_relpath hi hello howdy ) || true
   [ "${found[0]}" = "/foo/bar/baz/hi" ]
   [ "${found[1]}" = "/foo/bar/baz/hello" ]
   [ "${found[2]}" = "/foo/bar/baz/howdy" ]
   [ "${found[3]}" = "/foo/bar/hi" ]
   [ "${found[7]}" = "/foo/hello" ]
-  [ "${found[${#found[@]} - 1]}" = "/howdy" ]
+  [ "${found[${#found[@]} - 1]}" = "''/howdy" ]
 }
 
 # vim: ft=sh

--- a/t/detect_virtualenv.bats
+++ b/t/detect_virtualenv.bats
@@ -32,15 +32,6 @@ function setup() {
   [ "$_SWITCH_TO" = "first" ]
 }
 
-@test "prefer \$VIRTUAL_ENV if found" {
-  function find_virtualenvs() {
-    fake_find_virtualenv "." "$@"
-  }
-  VIRTUAL_ENV=this_virtualenv
-  detect_virtualenv foo:bar:this_virtualenv:baz
-  [ "$_SWITCH_TO" = "this_virtualenv" ]
-}
-
 @test "switch to \"\" if no dirs found" {
   function find_virtualenvs() {
     fake_find_virtualenv '^$' "$@"

--- a/t/detect_virtualenv.bats
+++ b/t/detect_virtualenv.bats
@@ -11,7 +11,7 @@ function setup() {
   function fake_find_virtualenv() {
     local pattern
     pattern=$1; shift
-    echo "$@" | xargs -n1 | grep "$pattern" | while read l; do printf "%s\0" "$l"; done
+    echo "$@" | xargs -n1 | grep "$pattern"
   }
 }
 

--- a/t/find_virtualenvs.bats
+++ b/t/find_virtualenvs.bats
@@ -40,7 +40,7 @@ function teardown_corpus() {
 
 @test "dir to find is starting dir" {
   local tempdir=$( get_tempdir_name )
-  local found=$( cd "$tempdir/foo/bar/baz"; ancestors_of | append_relpath baz | has_activate_script | xargs -n1 -0 | head -1 )
+  local found=$( cd "$tempdir/foo/bar/baz"; find_virtualenvs 'baz' | first0 )
   #
   # $tempdir
   # ├── foo
@@ -56,7 +56,7 @@ function teardown_corpus() {
 
 @test "dir to find is in starting dir" {
   local tempdir=$( get_tempdir_name )
-  local found=$( find_dir_in_parents 'baz' "$tempdir/foo/bar" )
+  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'baz' | first0 )
   #
   # $tempdir
   # ├── foo
@@ -75,13 +75,13 @@ function teardown_corpus() {
       builtin cd "$tempdir/bie/bletch"
   }
   local tempdir=$( get_tempdir_name )
-  local found=$( find_dir_in_parents 'baz' "$tempdir/foo/bar" )
+  local found=$( builtin cd "$tempdir/foo/bar"; find_virtualenvs 'baz' | first0 )
   [ "$found" = "$tempdir/foo/bar/baz" ]
 }
 
 @test "dir to find is sibling of starting dir" {
   local tempdir=$( get_tempdir_name )
-  local found=$( find_dir_in_parents 'bie' "$tempdir/foo/bar" )
+  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'bie' | first0 )
   #
   # $tempdir
   # ├── foo
@@ -97,7 +97,7 @@ function teardown_corpus() {
 
 @test "dir to find is parent's sibling" {
   local tempdir=$( get_tempdir_name )
-  local found=$( find_dir_in_parents 'quux' "$tempdir/foo/bar" )
+  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'quux' | first0 )
   #
   # $tempdir
   # ├── foo
@@ -113,7 +113,7 @@ function teardown_corpus() {
 
 @test "dir to find is in sibling (not found)" {
   local tempdir=$( get_tempdir_name )
-  local found=$( find_dir_in_parents 'bletch' "$tempdir/foo/bar" )
+  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'bletch' | first0 )
   #
   # $tempdir
   # ├── foo
@@ -130,7 +130,7 @@ function teardown_corpus() {
 @test "dir to find is sibling/child" {
   skip "can only find dirs whose dirname is . OR are abs paths"
   local tempdir=$( get_tempdir_name )
-  local found=$( find_dir_in_parents 'bie/bletch' "$tempdir/foo/bar" )
+  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'bie/bletch' | first0 )
   #
   # $tempdir
   # ├── foo
@@ -146,13 +146,13 @@ function teardown_corpus() {
 
 @test "dir to find doesn't exist (not found)" {
   local tempdir=$( get_tempdir_name )
-  local found=$( find_dir_in_parents 'xyzzy' "$tempdir/foo/bar" )
+  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'xyzzy' | first0 )
   [ -z "$found" ]
 }
 
 @test "start dir doesn't exist (nothing found)" {
   local tempdir=$( get_tempdir_name )
-  local found=$( find_dir_in_parents 'foo' "$tempdir/foobar" )
+  local found=$( cd "$tempdir/foobar"; find_virtualenvs 'foo' | first0 )
   [ -z "$found" ]
 }
 
@@ -165,13 +165,13 @@ function teardown_corpus() {
 
 @test "abs path to find and it's a sibling of an ancestor" {
   local tempdir=$( get_tempdir_name )
-  local found=$( find_dir_in_parents "$tempdir/quux" "$tempdir/foo/bar" )
+  local found=$( cd "$tempdir/foo/bar"; VIRTUAL_ENV="$tempdir/quux" find_virtualenvs | first0 )
   [ "$found" = "$tempdir/quux" ]
 }
 
 @test "abs path to find but it's not a sibling of an ancestor (not found)" {
   local tempdir=$( get_tempdir_name )
-  local found=$( find_dir_in_parents "$tempdir/quux/quuux" "$tempdir/foo/bar" )
+  local found=$( cd "$tempdir/foo/bar"; VIRTUAL_ENV="$tmpdir/quux/quuux" find_virtualenvs | first0 )
   [ -z "$found" ]
 }
 

--- a/t/find_virtualenvs.bats
+++ b/t/find_virtualenvs.bats
@@ -70,23 +70,6 @@ function teardown_corpus() {
   [ "$found" = "$tempdir/foo/bar/baz" ]
 }
 
-@test "starting dir defaults to cwd" {
-  local tempdir=$( get_tempdir_name )
-  builtin cd "$tempdir/foo/bar"
-  local found=$( find_dir_in_parents 'baz' )
-  #
-  # $tempdir
-  # ├── foo
-  # │   ├── bar        # start
-  # │   │   └── baz    # found
-  # │   └── bie
-  # │       └── bletch
-  # └── quux
-  #     └── quuux
-  #
-  [ "$found" = "$tempdir/foo/bar/baz" ]
-}
-
 @test "ignores non-builtin cd" {
   function cd() {
       echo hi

--- a/t/find_virtualenvs.bats
+++ b/t/find_virtualenvs.bats
@@ -139,12 +139,7 @@ function teardown_corpus() {
 }
 
 @test "dir to find doesn't exist (not found)" {
-  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'xyzzy' | first0 )
-  [ -z "$found" ]
-}
-
-@test "start dir doesn't exist (nothing found)" {
-  local found=$( cd "$tempdir/foobar"; find_virtualenvs 'foo' | first0 )
+  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'xyzzy' | head -1 )
   [ -z "$found" ]
 }
 

--- a/t/find_virtualenvs.bats
+++ b/t/find_virtualenvs.bats
@@ -11,6 +11,7 @@ function setup() {
       [ -d "${candidate}" ] && printf "%s\0" "$candidate"
     done
   }
+  tempdir=$( get_tempdir_name )
 }
 
 function teardown() {
@@ -39,7 +40,6 @@ function teardown_corpus() {
 }
 
 @test "dir to find is starting dir" {
-  local tempdir=$( get_tempdir_name )
   local found=$( cd "$tempdir/foo/bar/baz"; find_virtualenvs 'baz' | first0 )
   #
   # $tempdir
@@ -55,7 +55,6 @@ function teardown_corpus() {
 }
 
 @test "dir to find is in starting dir" {
-  local tempdir=$( get_tempdir_name )
   local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'baz' | first0 )
   #
   # $tempdir
@@ -74,13 +73,11 @@ function teardown_corpus() {
   function cd() {
       builtin cd "$tempdir/bie/bletch"
   }
-  local tempdir=$( get_tempdir_name )
   local found=$( builtin cd "$tempdir/foo/bar"; find_virtualenvs 'baz' | first0 )
   [ "$found" = "$tempdir/foo/bar/baz" ]
 }
 
 @test "dir to find is sibling of starting dir" {
-  local tempdir=$( get_tempdir_name )
   local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'bie' | first0 )
   #
   # $tempdir
@@ -96,7 +93,6 @@ function teardown_corpus() {
 }
 
 @test "dir to find is parent's sibling" {
-  local tempdir=$( get_tempdir_name )
   local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'quux' | first0 )
   #
   # $tempdir
@@ -112,7 +108,6 @@ function teardown_corpus() {
 }
 
 @test "dir to find is in sibling (not found)" {
-  local tempdir=$( get_tempdir_name )
   local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'bletch' | first0 )
   #
   # $tempdir
@@ -129,7 +124,6 @@ function teardown_corpus() {
 
 @test "dir to find is sibling/child" {
   skip "can only find dirs whose dirname is . OR are abs paths"
-  local tempdir=$( get_tempdir_name )
   local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'bie/bletch' | first0 )
   #
   # $tempdir
@@ -145,32 +139,27 @@ function teardown_corpus() {
 }
 
 @test "dir to find doesn't exist (not found)" {
-  local tempdir=$( get_tempdir_name )
   local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'xyzzy' | first0 )
   [ -z "$found" ]
 }
 
 @test "start dir doesn't exist (nothing found)" {
-  local tempdir=$( get_tempdir_name )
   local found=$( cd "$tempdir/foobar"; find_virtualenvs 'foo' | first0 )
   [ -z "$found" ]
 }
 
 @test "no dir to find given (nothing found)" {
-  local tempdir=$( get_tempdir_name )
   builtin cd "$tempdir/foo/bar"
   local found=$( find_dir_in_parents )
   [ -z "$found" ]
 }
 
 @test "abs path to find and it's a sibling of an ancestor" {
-  local tempdir=$( get_tempdir_name )
   local found=$( cd "$tempdir/foo/bar"; VIRTUAL_ENV="$tempdir/quux" find_virtualenvs | first0 )
   [ "$found" = "$tempdir/quux" ]
 }
 
 @test "abs path to find but it's not a sibling of an ancestor (not found)" {
-  local tempdir=$( get_tempdir_name )
   local found=$( cd "$tempdir/foo/bar"; VIRTUAL_ENV="$tmpdir/quux/quuux" find_virtualenvs | first0 )
   [ -z "$found" ]
 }

--- a/t/find_virtualenvs.bats
+++ b/t/find_virtualenvs.bats
@@ -70,10 +70,9 @@ function teardown_corpus() {
   [ "$found" = "$tempdir/foo/bar/baz" ]
 }
 
-@test "ignores non-builtin cd" {
+@test "doesn't mind if cd is not the same as builtin cd" {
   function cd() {
-      echo hi
-      builtin cd $@
+      builtin cd "$tempdir/bie/bletch"
   }
   local tempdir=$( get_tempdir_name )
   local found=$( find_dir_in_parents 'baz' "$tempdir/foo/bar" )

--- a/t/find_virtualenvs.bats
+++ b/t/find_virtualenvs.bats
@@ -5,6 +5,12 @@ function setup() {
   begin && run setup_corpus
   PATH="$BATS_TEST_DIRNAME/..:$PATH"
   source detect_virtualenv
+  function has_activate_script() {
+    while read -r -d '' candidate
+    do
+      [ -d "${candidate}" ] && printf "%s\0" "$candidate"
+    done
+  }
 }
 
 function teardown() {
@@ -14,7 +20,6 @@ function teardown() {
 
 function setup_corpus() {
   local tempdir=$( make_tempdir )
-  local found=$( find_dir_in_parents "quux" "$tempdir/foo/bar" )
   #
   # $tempdir
   # ├── foo
@@ -35,7 +40,7 @@ function teardown_corpus() {
 
 @test "dir to find is starting dir" {
   local tempdir=$( get_tempdir_name )
-  local found=$( find_dir_in_parents 'baz' "$tempdir/foo/bar/baz" )
+  local found=$( cd "$tempdir/foo/bar/baz"; ancestors_of | append_relpath baz | has_activate_script | xargs -n1 -0 | head -1 )
   #
   # $tempdir
   # ├── foo

--- a/t/find_virtualenvs.bats
+++ b/t/find_virtualenvs.bats
@@ -6,9 +6,10 @@ function setup() {
   PATH="$BATS_TEST_DIRNAME/..:$PATH"
   source detect_virtualenv
   function has_activate_script() {
-    while read -r -d '' candidate
+    while read -r candidate
     do
-      [ -d "${candidate}" ] && printf "%s\0" "$candidate"
+      local unescaped_candidate=$(printf "%b" "$candidate")
+      [ -d "${unescaped_candidate}" ] && echo "$candidate"
     done
   }
   tempdir=$( get_tempdir_name )
@@ -40,7 +41,7 @@ function teardown_corpus() {
 }
 
 @test "dir to find is starting dir" {
-  local found=$( cd "$tempdir/foo/bar/baz"; find_virtualenvs 'baz' | first0 )
+  local found=$( cd "$tempdir/foo/bar/baz"; find_virtualenvs 'baz' | head -1 )
   #
   # $tempdir
   # ├── foo
@@ -55,7 +56,7 @@ function teardown_corpus() {
 }
 
 @test "dir to find is in starting dir" {
-  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'baz' | first0 )
+  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'baz' | head -1 )
   #
   # $tempdir
   # ├── foo
@@ -73,12 +74,12 @@ function teardown_corpus() {
   function cd() {
       builtin cd "$tempdir/bie/bletch"
   }
-  local found=$( builtin cd "$tempdir/foo/bar"; find_virtualenvs 'baz' | first0 )
+  local found=$( builtin cd "$tempdir/foo/bar"; find_virtualenvs 'baz' | head -1 )
   [ "$found" = "$tempdir/foo/bar/baz" ]
 }
 
 @test "dir to find is sibling of starting dir" {
-  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'bie' | first0 )
+  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'bie' | head -1 )
   #
   # $tempdir
   # ├── foo
@@ -93,7 +94,7 @@ function teardown_corpus() {
 }
 
 @test "dir to find is parent's sibling" {
-  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'quux' | first0 )
+  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'quux' | head -1 )
   #
   # $tempdir
   # ├── foo
@@ -108,7 +109,7 @@ function teardown_corpus() {
 }
 
 @test "dir to find is in sibling (not found)" {
-  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'bletch' | first0 )
+  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'bletch' | head -1 )
   #
   # $tempdir
   # ├── foo
@@ -144,17 +145,17 @@ function teardown_corpus() {
 
 @test "no dir to find given (nothing found)" {
   builtin cd "$tempdir/foo/bar"
-  local found=$( find_dir_in_parents )
+  local found=$( find_virtualenvs )
   [ -z "$found" ]
 }
 
 @test "abs path to find and it's a sibling of an ancestor" {
-  local found=$( cd "$tempdir/foo/bar"; VIRTUAL_ENV="$tempdir/quux" find_virtualenvs | first0 )
+  local found=$( cd "$tempdir/foo/bar"; VIRTUAL_ENV="$tempdir/quux" find_virtualenvs | head -1 )
   [ "$found" = "$tempdir/quux" ]
 }
 
 @test "abs path to find but it's not a sibling of an ancestor (not found)" {
-  local found=$( cd "$tempdir/foo/bar"; VIRTUAL_ENV="$tmpdir/quux/quuux" find_virtualenvs | first0 )
+  local found=$( cd "$tempdir/foo/bar"; VIRTUAL_ENV="$tmpdir/quux/quuux" find_virtualenvs | head -1 )
   [ -z "$found" ]
 }
 

--- a/t/find_virtualenvs.bats
+++ b/t/find_virtualenvs.bats
@@ -164,4 +164,9 @@ function teardown_corpus() {
   [ -z "$found" ]
 }
 
+@test "prefer \$VIRTUAL_ENV if found" {
+  local found=$( cd "$tempdir/foo/bar/baz"; VIRTUAL_ENV="$tempdir/quux" find_virtualenvs bar | head -1 )
+  [ "$found" = "$tempdir/quux" ]
+}
+
 # vim: ft=sh

--- a/t/find_virtualenvs.bats
+++ b/t/find_virtualenvs.bats
@@ -123,19 +123,18 @@ function teardown_corpus() {
 }
 
 @test "dir to find is sibling/child" {
-  skip "can only find dirs whose dirname is . OR are abs paths"
-  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'bie/bletch' | first0 )
+  local found=$( cd "$tempdir/foo/bar"; find_virtualenvs 'bie/bletch' | head -1 )
   #
   # $tempdir
   # ├── foo
   # │   ├── bar        # start
   # │   │   └── baz
   # │   └── bie
-  # │       └── bletch # not found
+  # │       └── bletch # found
   # └── quux
   #     └── quuux
   #
-  [ -z "$found" ]
+  [ "$found" = "$tempdir/foo/bie/bletch" ]
 }
 
 @test "dir to find doesn't exist (not found)" {

--- a/t/match_parent.bats
+++ b/t/match_parent.bats
@@ -1,20 +1,23 @@
 function setup() {
   PATH="$BATS_TEST_DIRNAME/..:$PATH"
   source detect_virtualenv
+  function abs_path() {
+    printf "${1%/}"
+  }
 }
 
 @test "recognise a dir whose parent is in our ancestry" {
-  found=$(printf "%s\0" /foo/bar/baz/ /foo/bar/ /foo/ / | match_parent /foo/bar/quux)
+  found=$(ancestors_of /foo/bar/baz/ | match_parent /foo/bar/quux)
   [ "$found" = "/foo/bar/quux" ]
 }
 
 @test "recognise dir as sibling to an ancestor when it has a weird character" {
-  found=$(printf "%s\0" /foo/bar/baz/ /foo/bar/ /foo/ / | match_parent $'/foo/bie\nhi')
+  found=$(ancestors_of /foo/bar/baz/ | match_parent $'/foo/bie\nhi')
   [ "$found" = $'/foo/bie\nhi' ]
 }
 
 @test "recognise dir as sibling to an ancestor when ancestors have weird characters" {
-  found=$(printf "/fo\no%s/\0" /bar/baz /bar '' | match_parent $'/fo\no/bie')
+  found=$(ancestors_of $'/fo\no/bar/baz/' | match_parent $'/fo\no/bie')
   [ "$found" = $'/fo\no/bie' ]
 }
 

--- a/t/match_parent.bats
+++ b/t/match_parent.bats
@@ -12,12 +12,12 @@ function setup() {
 }
 
 @test "recognise dir as sibling to an ancestor when it has a weird character" {
-  found=$(ancestors_of /foo/bar/baz/ | match_parent $'/foo/bie\nhi')
+  found="$( eval echo "$(ancestors_of /foo/bar/baz/ | match_parent $'/foo/bie\nhi')" )"
   [ "$found" = $'/foo/bie\nhi' ]
 }
 
 @test "recognise dir as sibling to an ancestor when ancestors have weird characters" {
-  found=$(ancestors_of $'/fo\no/bar/baz/' | match_parent $'/fo\no/bie')
+  found="$( eval echo "$(ancestors_of $'/fo\no/bar/baz/' | match_parent $'/fo\no/bie')" )"
   [ "$found" = $'/fo\no/bie' ]
 }
 

--- a/t/match_parent.bats
+++ b/t/match_parent.bats
@@ -1,0 +1,21 @@
+function setup() {
+  PATH="$BATS_TEST_DIRNAME/..:$PATH"
+  source detect_virtualenv
+}
+
+@test "recognise a dir whose parent is in our ancestry" {
+  found=$(printf "%s\0" /foo/bar/baz/ /foo/bar/ /foo/ / | match_parent /foo/bar/quux)
+  [ "$found" = "/foo/bar/quux" ]
+}
+
+@test "recognise dir as sibling to an ancestor when it has a weird character" {
+  found=$(printf "%s\0" /foo/bar/baz/ /foo/bar/ /foo/ / | match_parent $'/foo/bie\nhi')
+  [ "$found" = $'/foo/bie\nhi' ]
+}
+
+@test "recognise dir as sibling to an ancestor when ancestors have weird characters" {
+  found=$(printf "/fo\no%s/\0" /bar/baz /bar '' | match_parent $'/fo\no/bie')
+  [ "$found" = $'/fo\no/bie' ]
+}
+
+# vim: ft=sh

--- a/t/switch_virtualenvs.bats
+++ b/t/switch_virtualenvs.bats
@@ -4,7 +4,7 @@ load tmpdir
 function setup() {
   if begin
   then
-    local tempdir=$( make_tempdir )
+    tempdir=$( make_tempdir )
     mkdir -p "$tempdir/venv/bin"
     cat <<-"EOF" >"$tempdir/venv/bin/activate"
 		export _ACTIVATED_FOR=$BATS_TEST_NAME
@@ -12,6 +12,7 @@ function setup() {
   fi
   PATH="$BATS_TEST_DIRNAME/..:$PATH"
   source detect_virtualenv
+  tempdir=$( get_tempdir_name )
 }
 
 function teardown() {
@@ -27,14 +28,12 @@ function deactivate() {
 }
 
 @test "no current virtualenv and new one given" {
-  local tempdir=$( get_tempdir_name )
   switch_virtualenvs "$tempdir/venv"
   [ "$_ACTIVATED_FOR" = "$BATS_TEST_NAME" ]
   [ -z "$_DEACTIVATED_FOR" ]
 }
 
 @test "current virtualenv and no new one given" {
-  local tempdir=$( get_tempdir_name )
   VIRTUAL_ENV="currently a virtualenv is active"
   switch_virtualenvs
   [ -z "$_ACTIVATED_FOR" ]
@@ -42,14 +41,12 @@ function deactivate() {
 }
 
 @test "no current virtualenv and no new one given" {
-  local tempdir=$( get_tempdir_name )
   switch_virtualenvs
   [ -z "$_ACTIVATED_FOR" ]
   [ -z "$_DEACTIVATED_FOR" ]
 }
 
 @test "current virtualenv and new one given" {
-  local tempdir=$( get_tempdir_name )
   VIRTUAL_ENV="currently a virtualenv is active"
   switch_virtualenvs "$tempdir/venv"
   [ "$_ACTIVATED_FOR" = "$BATS_TEST_NAME" ]
@@ -57,7 +54,6 @@ function deactivate() {
 }
 
 @test "new virtualenv matches current is a no-op" {
-  local tempdir=$( get_tempdir_name )
   VIRTUAL_ENV="$tempdir/venv"
   switch_virtualenvs "$tempdir/venv"
   [ -z "$_ACTIVATED_FOR" ]

--- a/t/switch_virtualenvs.bats
+++ b/t/switch_virtualenvs.bats
@@ -7,7 +7,7 @@ function setup() {
     tempdir=$( make_tempdir )
     mkdir -p "$tempdir/venv/bin"
     cat <<-"EOF" >"$tempdir/venv/bin/activate"
-		export _ACTIVATED_FOR=$BATS_TEST_NAME
+		export _ACTIVATED_FOR="$BATS_TEST_NAME"
 	EOF
   fi
   PATH="$BATS_TEST_DIRNAME/..:$PATH"

--- a/t/toggle_status.bats
+++ b/t/toggle_status.bats
@@ -2,8 +2,8 @@ function setup() {
   PATH="$BATS_TEST_DIRNAME/..:$PATH"
   source detect_virtualenv
 
-  function find_dir_in_parents() {
-      echo "$@"
+  function find_virtualenvs() {
+      printf "%s\0" "$@"
   }
   function switch_virtualenvs() {
       _SWITCH_TO=$@


### PR DESCRIPTION
This changes how `detect_virtualenv` finds a target, from visiting each parent of the current dir for every candidate virtualenv name, to generating a list of possible candidates and testing them in order in a pipeline.

I expected to get a mild speedup from avoiding the nested loops, so I wrote [a basic performance test](https://gist.github.com/dgholz/b21cf7c569dad6c7073cec9dfd1f48fd). Here's the baseline performance: number of potential virtualenv names to check for (target is always last) is horizontal, number of subdirs we start from away from the target is vertical

  | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
0 | 733 | 789 | 729 | 726 | 723 | 737 | 759 | 720 | 730
1 | 972 | 978 | 979 | 963 | 964 | 967 | 969 | 967 | 1006
2 | 1243 | 1249 | 1213 | 1224 | 1226 | 1204 | 1199 | 1255 | 1204
3 | 1481 | 1505 | 1582 | 1440 | 1457 | 1484 | 1464 | 1646 | 1458
4 | 1769 | 2277 | 2964 | 2312 | 2120 | 1907 | 1971 | 2177 | 2878
5 | 3020 | 2526 | 2273 | 2608 | 2636 | 2828 | 2160 | 2054 | 2005
6 | 3188 | 2682 | 2534 | 2384 | 2396 | 2368 | 2779 | 2223 | 2358
7 | 3390 | 2893 | 2838 | 2551 | 2681 | 2786 | 2547 | 3038 | 3025
8 | 797 | 899 | 1117 | 1299 | 1478 | 1493 | 1378 | 1098 | 818

I learned that `bash` will execute each command in a pipeline in parallel, and will eagerly shut down the upstream commands once another command closes its `stdin` (which is what `EPIPE`/`SIGPIPE` signifies). This new implementation is 1-2 orders of magnitude faster:

  | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
0 | 31 | 41 | 35 | 44 | 47 | 46 | 35 | 56 | 32
1 | 36 | 50 | 45 | 39 | 28 | 57 | 34 | 38 | 49
2 | 76 | 58 | 35 | 52 | 48 | 33 | 35 | 48 | 42
3 | 38 | 47 | 36 | 39 | 41 | 40 | 34 | 36 | 43
4 | 39 | 45 | 43 | 51 | 33 | 44 | 35 | 47 | 33
5 | 44 | 39 | 36 | 56 | 36 | 46 | 36 | 39 | 36
6 | 44 | 28 | 41 | 43 | 73 | 81 | 91 | 66 | 66
7 | 51 | 93 | 64 | 40 | 36 | 38 | 39 | 41 | 39
8 | 46 | 42 | 47 | 40 | 45 | 45 | 52 | 40 | 50
