### PR TITLE
Only deactivate if deactivate exists

### DIFF
--- a/detect_virtualenv
+++ b/detect_virtualenv
@@ -46,7 +46,10 @@ function find_virtualenvs() {
 function switch_virtualenvs() {
     local new="$1"
     [ "$VIRTUAL_ENV" = "$new" ] && return
-    [ -n "${VIRTUAL_ENV+virtualenv active}" ] && deactivate
+    if [ -n "$VIRTUAL_ENV" ]
+    then
+        declare -f deactivate >/dev/null && deactivate || unset VIRTUAL_ENV
+    fi
     local activate="$new/bin/activate"
     test -e "$activate" && source "$activate"
     true

--- a/t/switch_virtualenvs.bats
+++ b/t/switch_virtualenvs.bats
@@ -59,3 +59,11 @@ function deactivate() {
   [ -z "$_ACTIVATED_FOR" ]
   [ -z "$_DEACTIVATED_FOR" ]
 }
+
+@test "no current virtualenv but \$VIRTUAL_ENV set" {
+  unset deactivate
+  VIRTUAL_ENV="not really a virtualenv"
+  switch_virtualenvs
+  [ -z "$_ACTIVATED_FOR" ]
+  [ -z "$VIRTUAL_ENV" ]
+}


### PR DESCRIPTION
Sometimes `$VIRTUAL_ENV` stays set even when a virtualenv isn't active. Let's check if `deactivate` is actually set before trying to call it (and unset `$VIRTUAL_ENV` if it's not).

fixes #14 